### PR TITLE
Db backup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .env
+pnpd_data

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 node_modules
-hb.db
-session.db
-migrations
 .env
+pnpd_data

--- a/knexfile.js
+++ b/knexfile.js
@@ -7,10 +7,11 @@ export default {
   development: {
     client: "better-sqlite3",
     connection: {
-      filename: "./hb.db",
+      filename: "pndpd.db",
     },
     useNullAsDefault: true,
     migrations: {
+      directory: "./pnpd_data/migrations",
       tableName: "knex_migrations",
     },
   },
@@ -18,10 +19,11 @@ export default {
   staging: {
     client: "better-sqlite3",
     connection: {
-      filename: "./hb.db",
+      filename: "pndpd.db",
     },
     useNullAsDefault: true,
     migrations: {
+      directory: "./pnpd_data/migrations",
       tableName: "knex_migrations",
     },
   },
@@ -29,10 +31,11 @@ export default {
   production: {
     client: "better-sqlite3",
     connection: {
-      filename: "./hb.db",
+      filename: "pndpd.db",
     },
     useNullAsDefault: true,
     migrations: {
+      directory: "./pnpd_data/migrations",
       tableName: "knex_migrations",
     },
   },

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
   "scripts": {
     "start": "node index.js",
     "dev": "nodemon index.js",
-    "reset-db": "rm -f hb.db && touch hb.db && npm run seed-data",
-    "reset-migrations": "rm -r migrations && sqlite3 hb.db < drop-migrations.sql",
-    "seed-data": "sqlite3 hb.db < seed-data.sql",
+    "reset-db": "rm -f pnpd_data/pnpd.db && touch pnpd_data/pnpd.db && npm run seed-data",
+    "reset-migrations": "rm -r pnpd_data/migrations && sqlite3 pnpd_data/pnpd.db < drop-migrations.sql",
+    "seed-data": "sqlite3 pnpd_data/pnpd.db < seed-data.sql",
     "reset-sessions": "rm -f session.db && touch session.db",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -1,0 +1,42 @@
+import { Router } from "express";
+import catchError from "../utils/catch_error.js";
+import Database from "better-sqlite3";
+import adminOnly from "./middleware/admin_only.js";
+
+export default function generateAdminRouter(app) {
+  const router = Router();
+  const adminAPI = new AdminAPI(app);
+
+  // router.use(adminOnly());
+  router.get("/export", catchError(adminAPI.exportHandler()));
+  router.post("/import", catchError(adminAPI.importHandler()));
+
+  return router;
+}
+
+class AdminAPI {
+  constructor(app) {
+    this.app = app;
+    this.db = this.openConnection();
+  }
+
+  openConnection() {
+    // assures that the better-sqlite3 connection will connect to the app database
+    let dbName = this.app.getDAO().getDB().client.connectionSettings.filename;
+    // creates new better-sqlite3 connection
+    return new Database(dbName);
+  }
+  exportHandler() {
+    return async (req, res, next) => {
+      console.log("backing up the db...");
+      res.sendStatus(200);
+    };
+  }
+
+  importHandler() {
+    return async (req, res, next) => {
+      console.log("replacing your database with target database...");
+      res.sendStatus(201);
+    };
+  }
+}

--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -20,14 +20,29 @@ class AdminAPI {
     this.db = this.openConnection();
   }
 
-  openConnection() {
+  async openConnection() {
     // assures that the better-sqlite3 connection will connect to the app database
-    let dbName = this.app.getDAO().getDB().client.connectionSettings.filename;
-    // creates new better-sqlite3 connection
-    return new Database(dbName);
+    await this.app.getDAO().createOne("hiithere", { name: "something" });
+    let knex = this.app.getDAO().getDB();
+    // creates better-sqlite3 connection
+    // let result = await knex.client.acquireConnection();
+    // console.log(result);
+    // console.log(result2);
+    console.log("this is the knex object: ", knex.context.client.pool);
+    setTimeout(() => {
+      console.log(
+        "this is the knex object after some time: ",
+        knex.context.client.pool
+      );
+    }, 40000);
+    // knex.context.client.pool.used[0].resource < this is the database connection from the pool
+    // console.log(dbName);
+    // return dbName;
+    // return new Database(dbName);
   }
   exportHandler() {
     return async (req, res, next) => {
+      // this.db().prepare("DROP TABLE IF EXISTS hiithere;").run();
       console.log("backing up the db...");
       res.sendStatus(200);
     };

--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -7,8 +7,7 @@ export default function generateAdminRouter(app) {
   const adminAPI = new AdminAPI(app);
 
   // router.use(adminOnly());
-  router.get("/export", catchError(adminAPI.exportHandler()));
-  router.post("/import", catchError(adminAPI.importHandler()));
+  router.get("/backup", catchError(adminAPI.backupHandler()));
 
   return router;
 }
@@ -18,23 +17,12 @@ class AdminAPI {
     this.app = app;
   }
 
-  exportHandler() {
+  backupHandler() {
     return async (req, res, next) => {
-      let connection = this.app.getDAO().sqlite3Connection;
-      let dbName = connection.name;
-      let newName = `backup_${Date.now()}_${dbName}`;
-      console.log(`Backing up ${dbName} as '${newName}'...`);
-
-      await this.app.getDAO().sqlite3Connection.backup(newName);
-      console.log("Backup Complete!");
+      await this.app.getDAO().dbBackup();
       res.sendStatus(200);
     };
   }
-
-  importHandler() {
-    return async (req, res, next) => {
-      console.log("replacing your database with target database...");
-      res.sendStatus(201);
-    };
-  }
 }
+
+

--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -1,6 +1,5 @@
 import { Router } from "express";
 import catchError from "../utils/catch_error.js";
-import Database from "better-sqlite3";
 import adminOnly from "./middleware/admin_only.js";
 
 export default function generateAdminRouter(app) {
@@ -17,33 +16,17 @@ export default function generateAdminRouter(app) {
 class AdminAPI {
   constructor(app) {
     this.app = app;
-    this.db = this.openConnection();
   }
 
-  async openConnection() {
-    // assures that the better-sqlite3 connection will connect to the app database
-    await this.app.getDAO().createOne("hiithere", { name: "something" });
-    let knex = this.app.getDAO().getDB();
-    // creates better-sqlite3 connection
-    // let result = await knex.client.acquireConnection();
-    // console.log(result);
-    // console.log(result2);
-    console.log("this is the knex object: ", knex.context.client.pool);
-    setTimeout(() => {
-      console.log(
-        "this is the knex object after some time: ",
-        knex.context.client.pool
-      );
-    }, 40000);
-    // knex.context.client.pool.used[0].resource < this is the database connection from the pool
-    // console.log(dbName);
-    // return dbName;
-    // return new Database(dbName);
-  }
   exportHandler() {
     return async (req, res, next) => {
-      // this.db().prepare("DROP TABLE IF EXISTS hiithere;").run();
-      console.log("backing up the db...");
+      let connection = this.app.getDAO().sqlite3Connection;
+      let dbName = connection.name;
+      let newName = `backup_${Date.now()}_${dbName}`;
+      console.log(`Backing up ${dbName} as '${newName}'...`);
+
+      await this.app.getDAO().sqlite3Connection.backup(newName);
+      console.log("Backup Complete!");
       res.sendStatus(200);
     };
   }

--- a/src/api/init_api.js
+++ b/src/api/init_api.js
@@ -8,6 +8,7 @@ import generateCustomRouter from "./custom.js";
 import generateSchemaRouter from "./schema.js";
 import generateUIRouter from "./ui.js";
 import generateAuthRouter from "./auth.js";
+import generateAdminRouter from "./admin.js";
 
 //Middleware
 import errorHandler from "./middleware/error_handler.js";
@@ -58,12 +59,14 @@ function initApi(app) {
   const authRouter = generateAuthRouter(app);
   const crudRouter = generateCrudRouter(app);
   const schemaRouter = generateSchemaRouter(app);
+  const adminRouter = generateAdminRouter(app);
   const customRouter = generateCustomRouter(app);
   const UIRouter = generateUIRouter(app);
 
   server.use("/api/auth", authRouter);
   server.use("/api", crudRouter);
   server.use("/api/schema", schemaRouter);
+  server.use("/admin", adminRouter);
   server.use("/", customRouter);
   server.use("/ui", UIRouter);
 

--- a/src/api/init_api.js
+++ b/src/api/init_api.js
@@ -22,8 +22,8 @@ import store from "better-sqlite3-session-store";
 import sqlite from "better-sqlite3";
 
 const SqliteStore = store(session);
-const db = new sqlite("session.db");
-// const db = new sqlite("session.db", { verbose: console.log });
+const db = new sqlite("pnpd_data/session.db");
+// const db = new sqlite("pnpd_data/session.db", { verbose: console.log });
 
 function initApi(app) {
   const server = express();

--- a/src/api/init_api.js
+++ b/src/api/init_api.js
@@ -1,5 +1,6 @@
 import express from "express";
 import dotenv from "dotenv";
+import fs from "fs";
 dotenv.config();
 
 //Routers
@@ -22,6 +23,7 @@ import store from "better-sqlite3-session-store";
 import sqlite from "better-sqlite3";
 
 const SqliteStore = store(session);
+if (!fs.existsSync("pnpd_data")) fs.mkdirSync("pnpd_data");
 const db = new sqlite("pnpd_data/session.db");
 // const db = new sqlite("pnpd_data/session.db", { verbose: console.log });
 

--- a/src/dao/dao.js
+++ b/src/dao/dao.js
@@ -1,6 +1,7 @@
 import knex from "knex";
 import { DatabaseError, BadRequestError } from "../utils/errors.js";
 import Column from "../models/column.js";
+import fs from "fs";
 
 /**
  * DAO (Data Access Object) Class
@@ -10,7 +11,6 @@ class DAO {
   constructor(dbFile, connection) {
     this.sqlite3Connection;
     this.db = connection ? connection : this._connect(dbFile, this);
-
   }
 
   /**
@@ -20,6 +20,8 @@ class DAO {
    * @returns {Knex Instance}
    */
   _connect(dbFile, thisDAO) {
+    if (!fs.existsSync("pnpd_data")) fs.mkdirSync("pnpd_data");
+
     let db = knex({
       client: "better-sqlite3",
       useNullAsDefault: true,
@@ -68,9 +70,13 @@ class DAO {
     // matches the filename from the full filepath
     let dbName = this.sqlite3Connection.name.match(/[^\\/]+$/)[0];
 
-    let newName = `pnpd_data/backup/backup_${Date.now()}_${dbName}`;
+    if (!fs.existsSync("pnpd_data/backup")) fs.mkdirSync("pnpd_data/backup");
+
+    let newName = `backup_${Date.now()}_${dbName}`;
+    let newPath = `pnpd_data/backup/${newName}`;
+
     console.log(`Backing up ${dbName} as '${newName}'...`);
-    await this.sqlite3Connection.backup(newName);
+    await this.sqlite3Connection.backup(newPath);
     console.log("Backup Complete!");
   }
 
@@ -118,7 +124,7 @@ class DAO {
    */
   async findTableById(id) {
     try {
-      console.log("this is this ---------", this)
+      console.log("this is this ---------", this);
       const table = await this.getDB()("tablemeta").select("*").where({ id });
       return table;
     } catch (e) {
@@ -151,7 +157,7 @@ class DAO {
   async getAll(tableName) {
     try {
       const rows = await this.getDB()(tableName).select("*");
-      console.log("we made it here!")
+      console.log("we made it here!");
       return rows;
     } catch (e) {
       throw new Error(e.message);

--- a/src/dao/dao.js
+++ b/src/dao/dao.js
@@ -10,6 +10,7 @@ class DAO {
   constructor(dbFile, connection) {
     this.sqlite3Connection;
     this.db = connection ? connection : this._connect(dbFile, this);
+
   }
 
   /**
@@ -61,8 +62,10 @@ class DAO {
    * @returns {undefined}
    */
   async dbBackup() {
-    // matches the filename from the full filepath
+    // adds a connection to the knex pool so dao has access to the raw sqlite3 connection
     await this.getDB()("tablemeta").select("*");
+
+    // matches the filename from the full filepath
     let dbName = this.sqlite3Connection.name.match(/[^\\/]+$/)[0];
 
     let newName = `pnpd_data/backup/backup_${Date.now()}_${dbName}`;

--- a/src/dao/dao.js
+++ b/src/dao/dao.js
@@ -53,6 +53,19 @@ class DAO {
   }
 
   /**
+   * Uses better-sqlite3 connection to run a backup on the same knex connection as main app is using.
+   * @params
+   * @returns {undefined}
+   */
+  async dbBackup() {
+    let dbName = this.sqlite3Connection.name;
+    let newName = `backup_${Date.now()}_${dbName}`;
+    console.log(`Backing up ${dbName} as '${newName}'...`);
+    await this.sqlite3Connection.backup(newName);
+    console.log("Backup Complete!");
+  }
+
+  /**
    * Creates a transaction and invokes the callback given.
    * If the callback is successful, it commits the transaction.
    * Otherwise, it'll rollback the transaction.

--- a/src/dao/dao.js
+++ b/src/dao/dao.js
@@ -24,6 +24,7 @@ class DAO {
       connection: {
         filename: "hb.db",
       },
+      debug: true,
       // pool: {
       //   min: 0,
       // },

--- a/src/models/table.js
+++ b/src/models/table.js
@@ -194,7 +194,7 @@ class Table {
     });
 
     const migrateTemplate = `
-      import DAO from "../src/dao/dao.js";
+      import DAO from "../../src/dao/dao.js";
 
       export async function up(knex) {
         const dao = new DAO("", knex);
@@ -234,7 +234,7 @@ class Table {
     });
 
     const migrateTemplate = `
-        import DAO from "../src/dao/dao.js";
+        import DAO from "../../src/dao/dao.js";
 
         export async function up(knex) {
           const dao = new DAO("", knex);
@@ -284,7 +284,7 @@ class Table {
     });
 
     const migrateTemplate = `
-    import DAO from "../src/dao/dao.js";
+    import DAO from "../../src/dao/dao.js";
 
     export async function up(knex) {
       const oldTable = ${JSON.stringify(this)};

--- a/test/admin.rest
+++ b/test/admin.rest
@@ -1,10 +1,2 @@
 ### Create a backup of the database
-GET http://localhost:3000/admin/export
-### Import a database
-POST http://localhost:3000/admin/import
-content-type : application/json
-
-{
-  "username": "test",
-  "password": "password"
-}
+GET http://localhost:3000/admin/backup

--- a/test/admin.rest
+++ b/test/admin.rest
@@ -1,0 +1,10 @@
+### Create a backup of the database
+GET http://localhost:3000/admin/export
+### Import a database
+POST http://localhost:3000/admin/import
+content-type : application/json
+
+{
+  "username": "test",
+  "password": "password"
+}

--- a/test/schema.rest
+++ b/test/schema.rest
@@ -1,3 +1,6 @@
+GET http://localhost:3000/api/schema
+###
+
 POST http://localhost:3000/api/schema
 content-type : application/json
 


### PR DESCRIPTION
There are two main things this branch changes:
1. Moves all database files into a `pnpd_data` folder.
  - This required minor changes to all database file paths as well as where migrations get saved.
  - Added code before either the session or main database is created/connected to to make sure the files are created if they aren't there already.
 
2. Adds the ability to backup the database.
  - Added a new route as part of the `admin.js` api file. Currently the middleware to verify that someone hitting that route is an admin is commented out. 
  - Knex doesn't support making backups as part of their api, `better-sqlite3` does support backups. However, the backup method will restart the backup process if any *other* connection mutates the database while backup is on going. To allow the app to still write changes to the database while a backup is ongoing if set it up so that when a new instance of the Dao is instantiated as part of the `knex` config `afterCreate` callback function that it assigns the raw sqlite3 connection to a property of the `DAO`: `sqlite3Connection`. It's a bit round-about, but I've confirmed that the raw connection is the same as the connection used by knex from then on.
  - Added a corresponding `dbBackup()` method to the DAO class to do the backup. This method gets the name of the database from the current connection and initiates a backup of the database with a time-stamp prepended to the file name. As an artifact of how we give the DAO access to the raw better-sqlite3 connection the first line of the method makes a request to the database using the knex connection to make sure that the `this.sqlite3Connection` property gets assigned to the raw connection.
