### PR TITLE
Updated dbBackup to run a more efficient/robust query

### DIFF
--- a/src/dao/dao.js
+++ b/src/dao/dao.js
@@ -63,7 +63,9 @@ class DAO {
    */
   async getRawSqliteConnection() {
     // adds a connection to the knex pool so dao has access to the raw sqlite3 connection
-    await this.getDB()("sqlite_master").select("*").limit(1);
+    if (!this.sqlite3Connection) {
+      await this.getDB()("sqlite_master").select("*").limit(1);
+    }
     return this.sqlite3Connection;
   }
 

--- a/src/dao/dao.js
+++ b/src/dao/dao.js
@@ -59,16 +59,24 @@ class DAO {
   }
 
   /**
+   * @returns {object better-sqlite3 connection}
+   */
+  async getRawSqliteConnection() {
+    // adds a connection to the knex pool so dao has access to the raw sqlite3 connection
+    await this.getDB()("sqlite_master").select("*").limit(1);
+    return this.sqlite3Connection;
+  }
+
+  /**
    * Uses better-sqlite3 connection to run a backup on the same knex connection as main app is using.
    * @params
    * @returns {undefined}
    */
   async dbBackup() {
-    // adds a connection to the knex pool so dao has access to the raw sqlite3 connection
-    await this.getDB()("sqlite_master").select("*").limit(1);
+    let connection = await this.getRawSqliteConnection();
 
     // matches the filename from the full filepath
-    let dbName = this.sqlite3Connection.name.match(/[^\\/]+$/)[0];
+    let dbName = connection.name.match(/[^\\/]+$/)[0];
 
     if (!fs.existsSync("pnpd_data/backup")) fs.mkdirSync("pnpd_data/backup");
 
@@ -76,7 +84,7 @@ class DAO {
     let newPath = `pnpd_data/backup/${newName}`;
 
     console.log(`Backing up ${dbName} as '${newName}'...`);
-    await this.sqlite3Connection.backup(newPath);
+    await connection.backup(newPath);
     console.log("Backup Complete!");
   }
 

--- a/src/dao/dao.js
+++ b/src/dao/dao.js
@@ -65,7 +65,7 @@ class DAO {
    */
   async dbBackup() {
     // adds a connection to the knex pool so dao has access to the raw sqlite3 connection
-    await this.getDB()("tablemeta").select("*");
+    await this.getDB()("sqlite_master").select("*").limit(1);
 
     // matches the filename from the full filepath
     let dbName = this.sqlite3Connection.name.match(/[^\\/]+$/)[0];


### PR DESCRIPTION
`dbBackup()` method in the DAO runs a query on the table to establish a connection before running the backup. I changed the table it was querying to be the `sqlite_schema` and limit the results to 1. 

Previously the method was was querying `tablemeta` which is a custom table we place on the database. Changes make the query more robust if something goes wrong with the database and slightly faster with the limit 1.