### PR TITLE
Wal cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "start": "node index.js",
     "prod": "node ./dist/Pinniped.js",
     "dev": "nodemon index.js",
-    "reset-db": "rm -f pnpd_data/pnpd.db && touch pnpd_data/pnpd.db && npm run seed-data",
+    "reset-db": "rm -f pnpd_data/pnpd.db && touch pnpd_data/pnpd.db && npm run seed-data && rm -f pnpd_data/pnpd.db-wal && rm -f pnpd_data/pnpd.db-shm",
     "reset-sessions": "rm -f pnpd_data/session.db && touch pnpd_data/session.db",
     "reset-migrations": "rm -r pnpd_data/migrations && sqlite3 pnpd_data/pnpd.db < pnpd_data/drop-migrations.sql",
     "seed-data": "sqlite3 pnpd_data/pnpd.db < pnpd_data/seed-data.sql",

--- a/src/Pinniped/Pinniped.js
+++ b/src/Pinniped/Pinniped.js
@@ -1,10 +1,11 @@
 import initApi from "../api/init_api.js";
 import DAO from "../dao/dao.js";
 import EventEmitter from "events";
+import handleProcessEvents from "../utils/handle_process_events.js";
 import { InvalidCustomRouteError } from "../utils/errors.js";
 
 /**
- * HB (HomeBase) Class
+ * Pinniped Class
  * Runs the application of the backend.
  * Offers extensibility of custom routes.
  */
@@ -81,8 +82,16 @@ class Pinniped {
     return this.DAO;
   }
 
+  /**
+   * Starts the server on the given port, and registers process event handlers.
+   * @param {number} port
+   */
+
   start(port) {
+    handleProcessEvents(this);
+
     const server = initApi(this);
+
     server.listen(port, () => {
       console.log(`Admin UI available at http://localhost:${port}/_`);
       console.log(`App listening at http://localhost:${port}`);

--- a/src/Pinniped/Pinniped.js
+++ b/src/Pinniped/Pinniped.js
@@ -1,7 +1,7 @@
 import initApi from "../api/init_api.js";
 import DAO from "../dao/dao.js";
 import EventEmitter from "events";
-import handleProcessEvents from "../utils/handle_process_events.js";
+import registerProcessListeners from "../utils/register_process_listeners.js";
 import { InvalidCustomRouteError } from "../utils/errors.js";
 
 /**
@@ -88,7 +88,7 @@ class Pinniped {
    */
 
   start(port) {
-    handleProcessEvents(this);
+    registerProcessListeners(this);
 
     const server = initApi(this);
 

--- a/src/api/init_api.js
+++ b/src/api/init_api.js
@@ -36,7 +36,7 @@ function initApi(app) {
         : "ui"
     )
   );
-  // server.use("/_", express.static("ui"));
+
   server.use(express.json());
   server.use(
     cors({

--- a/src/dao/dao.js
+++ b/src/dao/dao.js
@@ -41,10 +41,15 @@ class DAO {
       },
     });
 
+    console.log("Database connection established.");
+
     return db;
   }
 
-  disconnect() {}
+  disconnect() {
+    this.getDB().destroy();
+    console.log("Database connection closed.");
+  }
 
   /**
    * Obtains the Knex instance that connected to the database.

--- a/src/dao/dao.js
+++ b/src/dao/dao.js
@@ -41,14 +41,11 @@ class DAO {
       },
     });
 
-    console.log("Database connection established.");
-
     return db;
   }
 
-  disconnect() {
-    this.getDB().destroy();
-    console.log("Database connection closed.");
+  async disconnect() {
+    await this.getDB().destroy();
   }
 
   /**

--- a/src/utils/handle_process_events.js
+++ b/src/utils/handle_process_events.js
@@ -1,0 +1,19 @@
+import process from "process";
+
+const handleProcessEvents = (app) => {
+  // Close database connection and exit process
+  const cleanupAndExit = () => {
+    app.getDAO().disconnect();
+  };
+
+  // Triggerd when Ctrl+C is pressed
+  process.on("SIGINT", cleanupAndExit);
+
+  // Triggered when a Process manager shuts down the process, or a container is stopped
+  process.on("SIGTERM", cleanupAndExit);
+
+  // Triggered when an unhandled exception occurs
+  process.on("uncaughtException", cleanupAndExit);
+};
+
+export default handleProcessEvents;

--- a/src/utils/handle_process_events.js
+++ b/src/utils/handle_process_events.js
@@ -1,19 +1,42 @@
 import process from "process";
 
+/**
+ * Registers process event handlers to close the database connection
+ * and exit the process when the application is terminated.
+ * @param {object} app - The Pinniped application instance.
+ * @returns {undefined}
+ */
 const handleProcessEvents = (app) => {
-  // Close database connection and exit process
-  const cleanupAndExit = () => {
-    app.getDAO().disconnect();
+  /**
+   * Closes the database connection and exits the process with a status code of 0.
+   * @returns {Promise<void>}
+   */
+  const cleanExit = async () => {
+    await app.getDAO().disconnect();
+    console.log("\n Database connection closed");
+    process.exit(0);
+  };
+
+  /**
+   * Closes the database connection and exits the process with a status code of 1.
+   * @param {Error} error - The unhandled exception.
+   * @returns {Promise<void>}
+   */
+  const errorExit = async (error) => {
+    console.error("Uncaught Exception:", error);
+    await app.getDAO().disconnect();
+    console.log("\n Database connection closed");
+    process.exit(1);
   };
 
   // Triggerd when Ctrl+C is pressed
-  process.on("SIGINT", cleanupAndExit);
+  process.on("SIGINT", cleanExit);
 
   // Triggered when a Process manager shuts down the process, or a container is stopped
-  process.on("SIGTERM", cleanupAndExit);
+  process.on("SIGTERM", cleanExit);
 
   // Triggered when an unhandled exception occurs
-  process.on("uncaughtException", cleanupAndExit);
+  process.on("uncaughtException", errorExit);
 };
 
 export default handleProcessEvents;

--- a/src/utils/register_process_listeners.js
+++ b/src/utils/register_process_listeners.js
@@ -6,7 +6,7 @@ import process from "process";
  * @param {object} app - The Pinniped application instance.
  * @returns {undefined}
  */
-const handleProcessEvents = (app) => {
+const registerProcessListeners = (app) => {
   /**
    * Closes the database connection and exits the process with a status code of 0.
    * @returns {Promise<void>}
@@ -39,4 +39,4 @@ const handleProcessEvents = (app) => {
   process.on("uncaughtException", errorExit);
 };
 
-export default handleProcessEvents;
+export default registerProcessListeners;

--- a/test/schema.rest
+++ b/test/schema.rest
@@ -5,8 +5,8 @@ POST http://localhost:3000/api/schema
 content-type : application/json
 
 {
-  "name" : "Seals",
-  "columns" : [{"name":"size","type":"text"}]
+  "name" : "Bears",
+  "columns" : [{"name":"size","type":"text"}, {"name":"type", "type":"text"}]
 }
 ### Adds a table
 


### PR DESCRIPTION
### **Summary**
- Created a `registerProcessListeners` function in the utils folder for handling consistent database disconnection when the server is closed or crashes. 

```javascript
//register_process_listeners.js
import process from "process";

/**
 * Registers process event handlers to close the database connection
 * and exit the process when the application is terminated.
 * @param {object} app - The Pinniped application instance.
 * @returns {undefined}
 */
const registerProcessListeners = (app) => {
  /**
   * Closes the database connection and exits the process with a status code of 0.
   * @returns {Promise<void>}
   */
  const cleanExit = async () => {
    await app.getDAO().disconnect();
    console.log("\n Database connection closed");
    process.exit(0);
  };

  /**
   * Closes the database connection and exits the process with a status code of 1.
   * @param {Error} error - The unhandled exception.
   * @returns {Promise<void>}
   */
  const errorExit = async (error) => {
    console.error("Uncaught Exception:", error);
    await app.getDAO().disconnect();
    console.log("\n Database connection closed");
    process.exit(1);
  };

  // Triggerd when Ctrl+C is pressed
  process.on("SIGINT", cleanExit);

  // Triggered when a Process manager shuts down the process, or a container is stopped
  process.on("SIGTERM", cleanExit);

  // Triggered when an unhandled exception occurs
  process.on("uncaughtException", errorExit);
};

export default registerProcessListeners;

```
- Updated the stub `disconnect` method on the `DAO` class to close the `knex` connection when invoked

```javascript
  async disconnect() {
    await this.getDB().destroy();
  }
```
- Imported the `registerProcessListeners` within the `Pinniped.js` file, and invoked the function inside of the `start` method on the `Pinniped` class. 
```javascript
  start(port) {
    registerProcessListeners(this);

    const server = initApi(this);

    server.listen(port, () => {
      console.log(`Admin UI available at http://localhost:${port}/_`);
      console.log(`App listening at http://localhost:${port}`);
    });
  }
```
- Updated reset-db script in the `package.json` to remove the shm and wal files
