### PR TITLE
Schema route events

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,61 +12,66 @@ app.addRoute("GET", "/custom", (req, res, next) => {
 // add event-driven functionality
 app.onGetAllRows("Animals", "users").add((event) => {
   console.log("Triggered event: onGetAllRows");
-  // console.log(event.data);
 });
 
 app.onGetOneRow("Animals").add((event) => {
   console.log("Triggered event: GET ONE ROW");
-  console.log(event.data);
 });
 
 app.onUpdateOneRow("Animals").add((event) => {
   console.log("Triggered event: UPDATE ONE ROW");
-  console.log(event.data);
 });
 
 app.onDeleteOneRow("Animals").add((event) => {
   console.log("Triggered event: DELETE ONE ROW");
-  console.log(event.data);
 });
 
 app.onCreateOneRow("Animals").add((event) => {
   console.log("Triggered event: CREATE ONE ROW");
-  console.log(event.data);
 });
 
 app.onBackupDatabase().add((event) => {
   console.log("Triggered event: BACKUP_DATABASE");
-  console.log(event.data);
 });
 
 app.onLogout().add((event) => {
   console.log("Triggered event: LOGOUT");
-  console.log(event.data);
 });
 
 app.onLoginUser().add((event) => {
   console.log("Triggered event: LOGIN");
-  console.log(event.data);
 });
 
 app.onRegisterAdmin().add((event) => {
   console.log("Triggered event: ON_REGISTER_ADMIN");
-  console.log(event.data);
 });
 
 app.onLoginAdmin().add((event) => {
   console.log("Triggered event: LOGIN_ADMIN");
-  console.log(event.data);
 });
 
 app.onRegisterUser().add((event) => {
   console.log("Triggered event: REGISTER_USER");
-  console.log(event.data);
 });
 
 app.onCustomRoute().add((event) => {
   console.log("Triggered event: CUSTOM_ROUTE");
+});
+
+app.onGetTableMeta().add((event) => {
+  console.log("Triggered Event: TABLE_META_GET");
+});
+
+app.onCreateTable().add((event) => {
+  console.log("Triggered Event: CREATE TABLE");
+});
+
+app.onUpdateTable().add((event) => {
+  console.log("Triggered Event: UPDATE TABLE");
+});
+
+app.onDropTable().add((event) => {
+  console.log("Triggered Event: DROP TABLE");
 });
 
 app.start(3000);

--- a/src/Pinniped/Pinniped.js
+++ b/src/Pinniped/Pinniped.js
@@ -151,6 +151,22 @@ class Pinniped {
     return new PinnipedEvent(this.emitter, "CUSTOM_ROUTE");
   }
 
+  onGetTableMeta() {
+    return new PinnipedEvent(this.emitter, "GET_TABLE_META");
+  }
+
+  onCreateTable() {
+    return new PinnipedEvent(this.emitter, "CREATE_TABLE");
+  }
+
+  onUpdateTable() {
+    return new PinnipedEvent(this.emitter, "UPDATE_TABLE");
+  }
+
+  onDropTable() {
+    return new PinnipedEvent(this.emitter, "DROP_TABLE");
+  }
+
   /**
    * Returns the app's DAO instance.
    * @returns {object DAO}

--- a/src/Pinniped/Pinniped.js
+++ b/src/Pinniped/Pinniped.js
@@ -98,6 +98,30 @@ class Pinniped {
   }
 
   /**
+   * Returns the app's DAO instance.
+   * @returns {object DAO}
+   */
+  getDAO() {
+    return this.DAO;
+  }
+
+  /**
+   * Starts the server on the given port, and registers process event handlers.
+   * @param {number} port
+   */
+  start(port) {
+    registerProcessListeners(this);
+
+    const server = initApi(this);
+
+    server.listen(port, () => {
+      console.log(`\nServer started at: http://localhost:${port}`);
+      console.log(`├─ REST API: http://localhost:${port}/api`);
+      console.log(`└─ Admin UI: http://localhost:${port}/_/\n`);
+    });
+  }
+
+  /**
    * Returns an object that adds an event handler and trigger events of the type: "GET_ALL_ROWS".
    * The callback passed to add is executed when the event is heard on the passed in tables.
    * @param {...string} tables
@@ -165,30 +189,6 @@ class Pinniped {
 
   onDropTable() {
     return new PinnipedEvent(this.emitter, "DROP_TABLE");
-  }
-
-  /**
-   * Returns the app's DAO instance.
-   * @returns {object DAO}
-   */
-  getDAO() {
-    return this.DAO;
-  }
-
-  /**
-   * Starts the server on the given port, and registers process event handlers.
-   * @param {number} port
-   */
-  start(port) {
-    registerProcessListeners(this);
-
-    const server = initApi(this);
-
-    server.listen(port, () => {
-      console.log(`\nServer started at: http://localhost:${port}`);
-      console.log(`├─ REST API: http://localhost:${port}/api`);
-      console.log(`└─ Admin UI: http://localhost:${port}/_/\n`);
-    });
   }
 }
 

--- a/src/api/routers/admin.js
+++ b/src/api/routers/admin.js
@@ -24,7 +24,7 @@ class AdminAPI {
 
       const responseData = new ResponseData(req, res, { filePath });
 
-      this.app.onBackupDatabase().trigger(responseData);
+      await this.app.onBackupDatabase().trigger(responseData);
 
       if (responseData.responseSent()) return null;
 

--- a/src/api/routers/auth.js
+++ b/src/api/routers/auth.js
@@ -72,7 +72,7 @@ class AuthApi {
       const responseData = new ResponseData(req, res, {
         user: createdUser[0].username,
       });
-      this.app.onRegisterUser().trigger(responseData);
+      await this.app.onRegisterUser().trigger(responseData);
       if (responseData.responseSent()) return null;
 
       res.status(201).json(responseData.formatGeneralResponse());
@@ -110,7 +110,7 @@ class AuthApi {
       const responseData = new ResponseData(req, res, {
         user: createdAdmin[0].username,
       });
-      this.app.onRegisterAdmin().trigger(responseData);
+      await this.app.onRegisterAdmin().trigger(responseData);
       if (responseData.responseSent()) return null;
 
       res.status(201).json(responseData.formatGeneralResponse());
@@ -144,7 +144,7 @@ class AuthApi {
       const responseData = new ResponseData(req, res, {
         user: req.session.user,
       });
-      this.app.onLoginUser().trigger(responseData);
+      await this.app.onLoginUser().trigger(responseData);
       if (responseData.responseSent()) return null;
 
       res.status(200).send(responseData.formatGeneralResponse());
@@ -177,7 +177,7 @@ class AuthApi {
       const responseData = new ResponseData(req, res, {
         user: req.session.user,
       });
-      this.app.onLoginAdmin().trigger(responseData);
+      await this.app.onLoginAdmin().trigger(responseData);
       if (responseData.responseSent()) return null;
 
       res.status(200).send(responseData.formatGeneralResponse());
@@ -193,7 +193,7 @@ class AuthApi {
       console.log("Logging out user: ", req.session.user);
       const responseData = new ResponseData(req, res, "User Logged Out");
 
-      this.app.onLogout().trigger(responseData);
+      await this.app.onLogout().trigger(responseData);
 
       if (responseData.responseSent()) return null;
 

--- a/src/api/routers/crud.js
+++ b/src/api/routers/crud.js
@@ -93,7 +93,7 @@ class CrudApi {
       const responseData = new ResponseData(req, res, { table, rows });
 
       // Fire the onGetAllRows event
-      this.app.onGetAllRows().trigger(responseData);
+      await this.app.onGetAllRows().trigger(responseData);
 
       // If a registered event handler sends a response to the client, early return.
       if (responseData.responseSent()) return null;
@@ -124,7 +124,7 @@ class CrudApi {
 
       const responseData = new ResponseData(req, res, { table, rows: row });
 
-      this.app.onGetOneRow().trigger(responseData);
+      await this.app.onGetOneRow().trigger(responseData);
 
       if (responseData.responseSent()) return null;
 
@@ -156,7 +156,7 @@ class CrudApi {
         rows: createdRow,
       });
 
-      this.app.onCreateOneRow().trigger(responseData);
+      await this.app.onCreateOneRow().trigger(responseData);
 
       if (responseData.responseSent()) return null;
 
@@ -193,7 +193,7 @@ class CrudApi {
         rows: updatedRow,
       });
 
-      this.app.onUpdateOneRow().trigger(responseData);
+      await this.app.onUpdateOneRow().trigger(responseData);
       if (responseData.responseSent()) return null;
 
       res.status(200).json(responseData.formatOneResponse());
@@ -221,7 +221,7 @@ class CrudApi {
       await this.app.getDAO().deleteOne(table.name, rowId);
 
       const responseData = new ResponseData(req, res, { table, rows: row });
-      this.app.onDeleteOneRow().trigger(responseData);
+      await this.app.onDeleteOneRow().trigger(responseData);
 
       if (responseData.responseSent()) return null;
 

--- a/src/api/routers/schema.js
+++ b/src/api/routers/schema.js
@@ -55,7 +55,7 @@ class SchemaApi {
       allTableMeta = allTableMeta.map((table) => new Table(table));
 
       const responseData = new ResponseData(req, res, { allTableMeta });
-      this.app.onGetTableMeta().trigger(responseData);
+      await this.app.onGetTableMeta().trigger(responseData);
 
       if (responseData.responseSent()) return null;
 
@@ -75,7 +75,7 @@ class SchemaApi {
       await table.create();
 
       const responseData = new ResponseData(req, res, { table });
-      this.app.onCreateTable().trigger(responseData);
+      await this.app.onCreateTable().trigger(responseData);
 
       if (responseData.responseSent()) return null;
       res.status(200).json({ table });
@@ -97,7 +97,7 @@ class SchemaApi {
       await oldTable.updateTo(newTable);
 
       const responseData = new ResponseData(req, res, { oldTable, newTable });
-      this.app.onUpdateTable().trigger(responseData);
+      await this.app.onUpdateTable().trigger(responseData);
       if (responseData.responseSent()) return null;
 
       res.json({ table: newTable });
@@ -117,7 +117,7 @@ class SchemaApi {
       await tableToDelete.drop();
 
       const responseData = new ResponseData(req, res, { tableToDelete });
-      this.app.onDropTable().trigger(responseData);
+      await this.app.onDropTable().trigger(responseData);
 
       if (responseData.responseSent()) return null;
       res.status(204).end();

--- a/src/api/routers/schema.js
+++ b/src/api/routers/schema.js
@@ -53,6 +53,12 @@ class SchemaApi {
     return async (req, res, next) => {
       let allTableMeta = await this.app.getDAO().getAll("tablemeta");
       allTableMeta = allTableMeta.map((table) => new Table(table));
+
+      const responseData = new ResponseData(req, res, { allTableMeta });
+      this.app.onGetTableMeta().trigger(responseData);
+
+      if (responseData.responseSent()) return null;
+
       res.json({ tables: allTableMeta });
     };
   }
@@ -67,6 +73,11 @@ class SchemaApi {
     return async (req, res, next) => {
       const table = new Table(req.body);
       await table.create();
+
+      const responseData = new ResponseData(req, res, { table });
+      this.app.onCreateTable().trigger(responseData);
+
+      if (responseData.responseSent()) return null;
       res.status(200).json({ table });
     };
   }
@@ -84,6 +95,11 @@ class SchemaApi {
       const newTable = new Table(req.body);
 
       await oldTable.updateTo(newTable);
+
+      const responseData = new ResponseData(req, res, { oldTable, newTable });
+      this.app.onUpdateTable().trigger(responseData);
+      if (responseData.responseSent()) return null;
+
       res.json({ table: newTable });
     };
   }
@@ -100,6 +116,10 @@ class SchemaApi {
       const tableToDelete = res.locals.table;
       await tableToDelete.drop();
 
+      const responseData = new ResponseData(req, res, { tableToDelete });
+      this.app.onDropTable().trigger(responseData);
+
+      if (responseData.responseSent()) return null;
       res.status(204).end();
     };
   }

--- a/src/models/response_data.js
+++ b/src/models/response_data.js
@@ -17,14 +17,6 @@ export default class ResponseData {
     return { data: this.data };
   }
 
-  formatTableMetaResponse() {
-    return { tables: this.data.allTableMeta };
-  }
-
-  formatTableMetaOneResponse() {
-    return { table: this.data.table };
-  }
-
   formatAllResponse() {
     return {
       table: {

--- a/src/models/response_data.js
+++ b/src/models/response_data.js
@@ -17,6 +17,14 @@ export default class ResponseData {
     return { data: this.data };
   }
 
+  formatTableMetaResponse() {
+    return { tables: this.data.allTableMeta };
+  }
+
+  formatTableMetaOneResponse() {
+    return { table: this.data.table };
+  }
+
   formatAllResponse() {
     return {
       table: {


### PR DESCRIPTION
Adds events for all of the schema routes. I didn't use the `ResponseData` formatting methods when sending a response back to the client as each of the routes has a unique signature and adding methods for each of them was quite a lot of code for very little pay-off. We may want to standardize the return from each route if we want to use ResponseData in that way across the code-base.

I also added appropriate `await`s when the events get triggered so that the callback has a chance to run before a response is sent back to the client. 

Moved all events in `Pinniped.js` to the bottom of the class.