### PR TITLE
Migrations durability

### DIFF
--- a/knexfile.js
+++ b/knexfile.js
@@ -7,7 +7,7 @@ export default {
   development: {
     client: "better-sqlite3",
     connection: {
-      filename: "pndpd.db",
+      filename: "pnpd_data/pnpd.db",
     },
     useNullAsDefault: true,
     migrations: {
@@ -19,7 +19,7 @@ export default {
   staging: {
     client: "better-sqlite3",
     connection: {
-      filename: "pndpd.db",
+      filename: "pnpd_data/pnpd.db",
     },
     useNullAsDefault: true,
     migrations: {
@@ -31,7 +31,7 @@ export default {
   production: {
     client: "better-sqlite3",
     connection: {
-      filename: "pndpd.db",
+      filename: "pnpd_data/pnpd.db",
     },
     useNullAsDefault: true,
     migrations: {

--- a/src/models/table.js
+++ b/src/models/table.js
@@ -182,6 +182,13 @@ class Table {
     this.columns.forEach((column) => column.initializeId());
   }
 
+  /**
+   * Attempts to run migration up, throws error and removes migration file and
+   * row from database.
+   * @param {knex instance} db
+   * @param {string} filePath
+   * @returns {undefined}
+   */
   async makeMigration(db, filePath) {
     const fileName = filePath.match(/[^\\/]+$/)[0];
     try {


### PR DESCRIPTION
This branch fixes the problem with failed migrations leaving you stuck trying to repeatedly run a migration that is failing. The main change is replacing `db.migrate.up()` after each migration file is made with the new `Table.prototype.makeMigration()` method: 
```javascript
  async makeMigration(db, filePath) {
    const fileName = filePath.match(/[^\\/]+$/)[0];
    try {
      await db.migrate.up();
    } catch (e) {
      console.log(
        "There was a problem making the migration. The migration file will be removed"
      );

      await db("knex_migrations").where({ name: fileName }).del();
      fs.unlinkSync(filePath);
      throw new Error(e);
    }
  }
```

The method tries to make the migration, if it fails it will remove the file from the migrations folder and also remove the corresponding row in the `knex_migrations` table of the database. This way, the Knex migration CLI tool works as intended. It's a clean rollback. After cleaning up the migration that failed, the catch-block re-throws the error that caused it (often helpful info from inside the migration file) which gets logged by the error handling middle-ware.

Also fixes for couple of migrations templates that were using `new DAO` vs the correct `new MigrationDao` in their `down` functions. 

Other change was that there was a typo introduced into `knexfile.js` at some point where running the migrations through the knex CLI would create a `pndpd.db` database file instead of using the correct `pnpd.db` file. 