### PR TITLE
Migrations on new database

### DIFF
--- a/rest/admin.rest
+++ b/rest/admin.rest
@@ -1,2 +1,2 @@
 ### Create a backup of the database
-GET http://localhost:3000/admin/backup
+POST http://localhost:3000/api/admin/backup

--- a/src/dao/dao.js
+++ b/src/dao/dao.js
@@ -20,6 +20,9 @@ class DAO {
    */
   _connect(thisDAO) {
     if (!fs.existsSync("pnpd_data")) fs.mkdirSync("pnpd_data");
+    if (!fs.existsSync("pnpd_data/migrations")) {
+      fs.mkdirSync("pnpd_data/migrations");
+    }
 
     let db = knex({
       client: "better-sqlite3",

--- a/src/models/table.js
+++ b/src/models/table.js
@@ -237,8 +237,8 @@ class Table {
     });
 
     const migrateTemplate = `
-      import { MigrationDao } from "pinniped";
-      //import { MigrationDao } from "../../src/Pinniped/Pinniped.js";
+      // import { MigrationDao } from "pinniped";
+      import { MigrationDao } from "../../src/pinniped/pinniped.js";
 
       export async function up(knex) {
         const dao = new MigrationDao(knex);
@@ -276,8 +276,8 @@ class Table {
     });
 
     const migrateTemplate = `
-        import { MigrationDao } from "pinniped";
-        // import { MigrationDao } from "../../src/Pinniped/Pinniped.js";
+        // import { MigrationDao } from "pinniped";
+        import { MigrationDao } from "../../src/pinniped/pinniped.js";
 
         export async function up(knex) {
           const dao = new MigrationDao(knex);
@@ -327,8 +327,8 @@ class Table {
     });
 
     const migrateTemplate = `
-    import { MigrationDao } from "pinniped";
-    // import { MigrationDao } from "../../src/Pinniped/Pinniped.js";
+    // import { MigrationDao } from "pinniped";
+    import { MigrationDao } from "../../src/pinniped/pinniped.js";
 
     export async function up(knex) {
       const oldTable = ${JSON.stringify(this)};


### PR DESCRIPTION
This branch adds an auto-migration feature to the `Pinniped` class that automatically runs the latest migrations on startup. This means that if you're restoring a backup all of the migrations that haven't run on that database will be run. This makes sure that you can seamlessly transition your migrations between development and production. 

```javascript
  async runLatestMigrations() {
    const tablemetaExists = await this.getDAO().tableExists("tablemeta");
    if (!tablemetaExists) {
      await this.getDAO().createTablemeta();
    }
    await this.DAO.getDB().migrate.latest();
  }
```
This method takes some of the functionality from the `seedDatabase` method to make sure that the database has `tablemeta` on it before attempting to run the migrations.