### PR TITLE
Creates route to send front end request to index.html

### DIFF
--- a/src/api/init_api.js
+++ b/src/api/init_api.js
@@ -1,6 +1,7 @@
 import express from "express";
 import dotenv from "dotenv";
 import fs from "fs";
+import { resolve } from "path";
 dotenv.config();
 
 //Routers
@@ -78,6 +79,21 @@ function initApi(app) {
   server.use("/api/schema", schemaRouter);
   server.use("/api/admin", adminRouter);
   server.use("/", customRouter);
+
+  // routes all of the front end routes back to index. Needed for static vite build
+  server.get(
+    [
+      "/_/",
+      "/_/login",
+      "/_/register",
+      "/_/observability",
+      "/_/data",
+      "/_/settings",
+    ],
+    (req, res, next) => {
+      res.sendFile(resolve("ui/index.html"));
+    }
+  );
 
   server.get("*", (req, res, next) => {
     res.send("Page does not exist");

--- a/src/api/init_api.js
+++ b/src/api/init_api.js
@@ -29,14 +29,7 @@ const db = new sqlite("pnpd_data/session.db");
 function initApi(app) {
   const server = express();
 
-  server.use(
-    "/_",
-    express.static(
-      fs.existsSync("node_modules/pinniped/ui")
-        ? "node_modules/pinniped/ui"
-        : "ui"
-    )
-  );
+  server.use("/_", express.static("node_modules/pinniped/ui"));
 
   server.use(express.json());
   server.use(
@@ -82,16 +75,9 @@ function initApi(app) {
 
   // routes all of the front end routes back to index. Needed for static vite build
   server.get(
-    [
-      "/_/",
-      "/_/login",
-      "/_/register",
-      "/_/observability",
-      "/_/data",
-      "/_/settings",
-    ],
+    ["/_/login", "/_/register", "/_/observability", "/_/data", "/_/settings"],
     (req, res, next) => {
-      res.sendFile(resolve("ui/index.html"));
+      res.sendFile(resolve("node_modules/pinniped/ui/index.html"));
     }
   );
 


### PR DESCRIPTION
Adds a route that catches all admin UI extension routes and serves the index.html file. This fixes issues in built versions of the front-end where it can't find the routes in the url and returns 404. UI is not being served by default from the pinniped dependency.
 
```javascript
  server.get(
    [
      "/_/login",
      "/_/register",
      "/_/observability",
      "/_/data",
      "/_/settings",
    ],
    (req, res, next) => {
      res.sendFile(resolve("node_modules/pinniped/ui/index.html"));
    }
  );
```