### PR TITLE
Observability

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prod": "node ./dist/Pinniped.js",
     "dev": "nodemon index.js",
     "reset-all": "npm run reset-sessions && npm run reset-migrations && npm run reset-db",
-    "reset-db": "rm -f pnpd_data/pnpd.db && touch pnpd_data/pnpd.db && rm -f pnpd_data/pnpd.db-wal && rm -f pnpd_data/pnpd.db-shm",
+    "reset-db": "rm -f pnpd_data/pnpd.db && touch pnpd_data/pnpd.db && rm -f pnpd_data/pnpd.db-wal && rm -f pnpd_data/pnpd.db-shm && rm -f pnpd_data/logs.db",
     "reset-sessions": "rm -f pnpd_data/session.db && touch pnpd_data/session.db",
     "reset-migrations": "rm -r pnpd_data/migrations && sqlite3 pnpd_data/pnpd.db < pnpd_data/drop-migrations.sql",
     "build": "npx parcel build index.js && npm run build-cleanup",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "express-session": "^1.18.0",
     "knex": "^3.1.0",
     "pinniped": "latest",
+    "pino-http": "^9.0.0",
     "xss": "^1.0.15"
   },
   "devDependencies": {

--- a/src/api/init_api.js
+++ b/src/api/init_api.js
@@ -1,5 +1,6 @@
 import express from "express";
 import dotenv from "dotenv";
+import pinoHttp from "pino-http";
 import fs from "fs";
 import { resolve } from "path";
 dotenv.config();
@@ -57,6 +58,8 @@ function initApi(app) {
       },
     })
   );
+
+  server.use(pinoHttp({ stream: app.logger.sqliteStream() }));
 
   server.use(sanitize());
   server.use(setHeaders());

--- a/src/api/init_api.js
+++ b/src/api/init_api.js
@@ -60,7 +60,6 @@ function initApi(app) {
   );
 
   server.use(pinoHttp({ stream: app.logger.sqliteStream() }));
-
   server.use(sanitize());
   server.use(setHeaders());
 

--- a/src/api/routers/admin.js
+++ b/src/api/routers/admin.js
@@ -10,6 +10,7 @@ export default function generateAdminRouter(app) {
   // router.use(adminOnly());
 
   router.get("/logs", catchError(adminAPI.getLogsHandler()));
+  router.delete("/logs/:id", catchError(adminAPI.deleteLogHandler()));
 
   router.post("/backup", catchError(adminAPI.backupHandler()));
 
@@ -26,6 +27,14 @@ class AdminAPI {
       const logs = await this.app.logger.getLogs();
 
       res.status(200).json({ logs });
+    };
+  }
+
+  deleteLogHandler() {
+    return async (req, res, next) => {
+      const { id } = req.params;
+      await this.app.logger.deleteLog(id);
+      res.status(204).end();
     };
   }
 

--- a/src/api/routers/admin.js
+++ b/src/api/routers/admin.js
@@ -7,7 +7,7 @@ export default function generateAdminRouter(app) {
   const router = Router();
   const adminAPI = new AdminAPI(app);
 
-  // router.use(adminOnly());
+  router.use(adminOnly());
 
   router.get("/logs", catchError(adminAPI.getLogsHandler()));
   router.delete("/logs/:id", catchError(adminAPI.deleteLogHandler()));

--- a/src/api/routers/admin.js
+++ b/src/api/routers/admin.js
@@ -7,7 +7,10 @@ export default function generateAdminRouter(app) {
   const router = Router();
   const adminAPI = new AdminAPI(app);
 
-  router.use(adminOnly());
+  // router.use(adminOnly());
+
+  router.get("/logs", catchError(adminAPI.getLogsHandler()));
+
   router.post("/backup", catchError(adminAPI.backupHandler()));
 
   return router;
@@ -16,6 +19,14 @@ export default function generateAdminRouter(app) {
 class AdminAPI {
   constructor(app) {
     this.app = app;
+  }
+
+  getLogsHandler() {
+    return async (req, res, next) => {
+      const logs = await this.app.logger.getLogs();
+
+      res.status(200).json({ logs });
+    };
   }
 
   backupHandler() {

--- a/src/dao/log_dao.js
+++ b/src/dao/log_dao.js
@@ -1,0 +1,81 @@
+import knex from "knex";
+
+class LogDao {
+  constructor() {
+    this.db = knex({
+      client: "better-sqlite3",
+      useNullAsDefault: true,
+      connection: {
+        filename: "pnpd_data/logs.db",
+      },
+    });
+  }
+
+  async createTable() {
+    const logsExists = await this.db.schema.hasTable("logs");
+
+    if (!logsExists) {
+      await this.db.schema.createTable("logs", (table) => {
+        table.specificType("id", "INTEGER PRIMARY KEY");
+        table.integer("level");
+        table.string("time");
+        table.string("hostname");
+        table.string("method");
+        table.string("url");
+        table.json("headers");
+        table.integer("statusCode");
+        table.integer("responseTime");
+      });
+    }
+  }
+
+  async getLogs() {
+    return this.db("logs").select("*");
+  }
+
+  async insertLog(log) {
+    return this.db("logs")
+      .insert(log)
+      .catch((err) => console.error(err));
+  }
+
+  sqliteStream() {
+    return {
+      write: (log) => {
+        const parsedLog = this.parseLog(log);
+        console.log("PARSED LOG", parsedLog);
+        if (parsedLog.url === "/api/admin/logs") return;
+        this.insertLog(parsedLog);
+      },
+    };
+  }
+
+  parseLog(log) {
+    const parsedLog = JSON.parse(log);
+    const copy = { ...parsedLog };
+
+    const {
+      pid: id,
+      level,
+      time,
+      hostname,
+      req: { method, url, headers },
+      res: { statusCode },
+      responseTime,
+    } = copy;
+
+    return {
+      id,
+      level,
+      time,
+      hostname,
+      method,
+      url,
+      headers,
+      statusCode,
+      responseTime,
+    };
+  }
+}
+
+export default LogDao;

--- a/src/pinniped/pinniped.js
+++ b/src/pinniped/pinniped.js
@@ -1,5 +1,6 @@
 import initApi from "../api/init_api.js";
 import DAO from "../dao/dao.js";
+import LogDao from "../dao/log_dao.js";
 import EventEmitter from "events";
 import registerProcessListeners from "../utils/register_process_listeners.js";
 import { InvalidCustomRouteError } from "../utils/errors.js";
@@ -18,6 +19,7 @@ class Pinniped {
 
   constructor(config) {
     this.DAO = new DAO();
+    this.logger = new LogDao();
     this.emitter = new EventEmitter();
     this.customRoutes = [];
     this.dataBaseSetup();
@@ -26,6 +28,7 @@ class Pinniped {
   async dataBaseSetup() {
     await this.runLatestMigrations();
     await this.seedDatabase();
+    await this.logger.createTable();
   }
   /**
    * Seeds the database with the necessary tables.


### PR DESCRIPTION
Created a logs database file to store the logs.

Created a LogDao class that contains methods to insert the logs into the logs database file through a Knex connection. For these methods to run on every log, there is a special method ```sqliteStream``` that is inserted into a Pino instance so it runs these LogDao methods on every log. Pino is what's used to log every request.

It optionally inserts the logs into ```logs.db``` depending on the path of the request. We assume that some logs are less important, and often not want to be added to the admin UI. For example, a delete request to delete a log on the admin UI shouldn't be added to the admin UI.

There are added routes to fetch all the logs in the database and deleting a specific log in the database based on the ID in the parameters. These routes are necessary for the admin UI to display these logs that are hitting the backend APIs.

Lastly, the ```reset-all``` script in ```package.json``` is updated to remove the ```logs.db``` file. As of right now, ```logs.db``` is not using WAL mode.
