### PR TITLE
Autocert server

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,17 @@
+# Base domain name to get SSL cert. ie. "example.com"
+SERVER_DOMAIN=
+
+# if SERVER_DOMAIN has a value will automatically add 'www.SERVER_DOMAIN' to ALTNAMES
+# comma seperate each value: www.example.com,www.example.net
+SERVER_ALTNAMES=
+
+# anything but production will default to getting staging cert from Let's Encrypt.
+SERVER_DIRECTORY=
+
+# Port used by http server on localhost
+SERVER_PORT=
+
+# comma seperate each domain that cors should allow: value1,value2,...
+CORS_WHITELIST=
+
+SESSION_SECRET=

--- a/.env.template
+++ b/.env.template
@@ -11,7 +11,8 @@ SERVER_DIRECTORY=
 # Port used by http server on localhost
 SERVER_PORT=
 
-# comma seperate each domain that cors should allow: value1,value2,...
+# can be regex or plaintext, if not provided, defaults to allow all
+# comma seperate each domain that cors should allow: www.example.com,/regexvalue/,www.example2.com
 CORS_WHITELIST=
 
 SESSION_SECRET=

--- a/index.js
+++ b/index.js
@@ -1,6 +1,12 @@
 import { pnpd } from "./src/pinniped/pinniped.js";
 
-const app = pnpd();
+let serverConfig = {
+  // domain: "jonathanhurd.net",
+  port: 3000,
+  // cors:
+};
+
+const app = pnpd(serverConfig);
 
 // Extensibility Invocations
 
@@ -14,4 +20,4 @@ app.onGetOneRow("seals").add((event) => {
   console.log("Triggered event: onGetAllRows");
 });
 
-app.start(3000);
+app.start();

--- a/index.js
+++ b/index.js
@@ -1,9 +1,12 @@
 import { pnpd } from "./src/pinniped/pinniped.js";
+import "dotenv/config";
 
+// see .env.template for comments on config properties
 let serverConfig = {
-  // domain: "jonathanhurd.net",
-  port: 3000,
-  // cors:
+  domain: process.env.SERVER_DOMAIN,
+  altNames: process.env.SERVER_ALTNAMES,
+  directory: process.env.SERVER_DIRECTORY,
+  port: process.env.SERVER_PORT,
 };
 
 const app = pnpd(serverConfig);

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "express-session": "^1.18.0",
     "helmet": "^7.1.0",
     "knex": "^3.1.0",
-    "node-forge": "^1.3.1",
     "node-schedule": "^2.1.1",
     "pino-http": "^9.0.0",
     "xss": "^1.0.15"

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "acme-client": "^5.3.0",
     "bcrypt": "^5.1.1",
     "better-sqlite3": "^9.4.3",
     "better-sqlite3-session-store": "^0.1.0",
@@ -48,6 +49,8 @@
     "express-session": "^1.18.0",
     "helmet": "^7.1.0",
     "knex": "^3.1.0",
+    "node-forge": "^1.3.1",
+    "node-schedule": "^2.1.1",
     "pino-http": "^9.0.0",
     "xss": "^1.0.15"
   },

--- a/src/api/init_api.js
+++ b/src/api/init_api.js
@@ -1,9 +1,8 @@
 import express from "express";
-import dotenv from "dotenv";
+import "dotenv/config";
 import fs from "fs";
 import pinoHttp from "pino-http";
 import { resolve } from "path";
-dotenv.config();
 
 //Routers
 import generateCrudRouter from "./routers/crud.js";
@@ -25,6 +24,7 @@ function initApi(app) {
   server.use("/_", express.static("node_modules/pinniped/ui"));
 
   server.use(express.json());
+  // cors: process.env.CORS_WHITELIST,
   server.use(
     cors({
       origin: true,

--- a/src/api/init_api.js
+++ b/src/api/init_api.js
@@ -21,16 +21,22 @@ import sessionConfig from "./middleware/session_config.js";
 function initApi(app) {
   const server = express();
 
-  server.use("/_", express.static("node_modules/pinniped/ui"));
+  let origin = true;
+  if (process.env.CORS_WHITELIST) {
+    origin = process.env.CORS_WHITELIST.split(",");
+  }
 
-  server.use(express.json());
-  // cors: process.env.CORS_WHITELIST,
   server.use(
     cors({
-      origin: true,
+      origin,
       credentials: true,
     })
   );
+
+  server.use("/_", express.static("node_modules/pinniped/ui"));
+
+  server.use(express.json());
+
   server.use(sessionConfig());
 
   server.use(pinoHttp({ stream: app.logger.sqliteStream() }));

--- a/src/api/middleware/session_config.js
+++ b/src/api/middleware/session_config.js
@@ -1,4 +1,3 @@
-//Session
 import session from "express-session";
 import store from "better-sqlite3-session-store";
 import sqlite from "better-sqlite3";

--- a/src/pinniped/pinniped.js
+++ b/src/pinniped/pinniped.js
@@ -130,12 +130,6 @@ class Pinniped {
 
     const server = new Server(expressApp, this.config);
     server.start();
-
-    // server.listen(port, () => {
-    //   console.log(`\nServer started at: http://localhost:${port}`);
-    //   console.log(`├─ REST API: http://localhost:${port}/api`);
-    //   console.log(`└─ Admin UI: http://localhost:${port}/_/\n`);
-    // });
   }
 
   /**

--- a/src/pinniped/pinniped.js
+++ b/src/pinniped/pinniped.js
@@ -6,6 +6,7 @@ import registerProcessListeners from "../utils/register_process_listeners.js";
 import { InvalidCustomRouteError } from "../utils/errors.js";
 import Table from "../models/table.js";
 import PinnipedEvent from "../models/pnpd_event.js";
+import Server from "./server.js";
 
 /**
  * Pinniped Class
@@ -18,6 +19,7 @@ class Pinniped {
   }
 
   constructor(config) {
+    this.config = config;
     this.DAO = new DAO();
     this.logger = new LogDao();
     this.emitter = new EventEmitter();
@@ -121,16 +123,19 @@ class Pinniped {
    * Starts the server on the given port, and registers process event handlers.
    * @param {number} port
    */
-  start(port) {
+  start() {
     registerProcessListeners(this);
 
-    const server = initApi(this);
+    const expressApp = initApi(this);
 
-    server.listen(port, () => {
-      console.log(`\nServer started at: http://localhost:${port}`);
-      console.log(`├─ REST API: http://localhost:${port}/api`);
-      console.log(`└─ Admin UI: http://localhost:${port}/_/\n`);
-    });
+    const server = new Server(expressApp, this.config);
+    server.start();
+
+    // server.listen(port, () => {
+    //   console.log(`\nServer started at: http://localhost:${port}`);
+    //   console.log(`├─ REST API: http://localhost:${port}/api`);
+    //   console.log(`└─ Admin UI: http://localhost:${port}/_/\n`);
+    // });
   }
 
   /**

--- a/src/pinniped/server.js
+++ b/src/pinniped/server.js
@@ -8,7 +8,6 @@ import {
 import { createServer } from "https";
 import express from "express";
 import { Client, directory, crypto } from "acme-client";
-import forge from "node-forge";
 import { RecurrenceRule, scheduleJob } from "node-schedule";
 
 class Server {
@@ -230,11 +229,8 @@ class Server {
    * @returns {bool}
    */
   #needsRenewal(cert) {
-    const certObj = acme.crypto.readCertificateInfo(cert);
-    // const certObj = forge.pki.certificateFromPem(cert);
-    console.log(certObj);
-    // return this.#daysUntil(certObj.validity.notAfter) < 31;
-    return false;
+    const certObj = crypto.readCertificateInfo(cert);
+    return this.#daysUntil(certObj.notAfter) < 31;
   }
 
   /**

--- a/src/pinniped/server.js
+++ b/src/pinniped/server.js
@@ -31,17 +31,18 @@ class Server {
       altNames: config.altNames || [],
       port: config.port || 3000,
       domain: config.domain,
-      cors: config.cors || [],
+      directory: config.directory,
     };
 
-    this.createAltNames();
-    console.log(this.config);
+    this.formatAltNames();
     this.credentials;
     this.challengeCache = {};
   }
 
-  createAltNames() {
-    if (this.config.domain && !this.config.altNames.length) {
+  formatAltNames() {
+    if (this.config.altNames.length) {
+      this.config.altNames = this.config.altNames.split(",");
+    } else if (this.config.domain && !this.config.altNames.length) {
       this.config.altNames.push("www." + this.config.domain);
     }
   }
@@ -264,11 +265,14 @@ class Server {
     }
     this.certServer.start();
 
+    let directoryUrl = directory.letsencrypt.staging;
+    if (this.config.directory === "production") {
+      directoryUrl = directory.letsencrypt.production;
+    }
+
     // Init client
     const client = new Client({
-      // uncomment this for production
-      // directoryUrl: directory.letsencrypt.production,
-      directoryUrl: directory.letsencrypt.staging,
+      directoryUrl,
       accountKey: await crypto.createPrivateKey(),
     });
 

--- a/src/pinniped/server.js
+++ b/src/pinniped/server.js
@@ -144,10 +144,13 @@ class Server {
   #createHttpsServer() {
     let httpsServer = {};
     httpsServer.server = createServer(this.credentials, this.expressApp);
+    const domain = this.config.domain;
 
     httpsServer.start = () => {
       this.httpsServer.server.listen(443, () => {
-        console.log("HTTPS server running on port 443");
+        console.log(`\nServer started at: https://${domain}`);
+        console.log(`├─ REST API: https://${domain}/api`);
+        console.log(`└─ Admin UI: https://${domain}/_/\n`);
       });
     };
 

--- a/src/pinniped/server.js
+++ b/src/pinniped/server.js
@@ -11,7 +11,16 @@ import { Client, directory, crypto } from "acme-client";
 import { RecurrenceRule, scheduleJob } from "node-schedule";
 
 class Server {
-  constructor(expressApp, config) {
+  /**
+   * @param {Object} expressApp
+   * @param {Object} config - server config object
+   * @param {string} [config.domain] - domain name to be used on certificate
+   * @param {string[]} [config.altNames] - alternate names to be used on cert (www.domain.com, www.sub.domain.com, etc)
+   * @param {number} [config.port] - default 3000, only used for http server. https runs on 80 and 443 only
+   * @returns {undefined}
+   */
+
+  constructor(expressApp, config = {}) {
     this.certServer = this.#createCertServer();
     this.httpsServer;
     this.httpServer;
@@ -355,11 +364,3 @@ class Server {
 }
 
 export default Server;
-// const app = express();
-
-// app.get("/", (req, res) => {
-//   res.send("Hi, this is seal!");
-// });
-
-// let server = new Server(this.expressApp, this.config);
-// server.start();

--- a/src/pinniped/server.js
+++ b/src/pinniped/server.js
@@ -230,8 +230,11 @@ class Server {
    * @returns {bool}
    */
   #needsRenewal(cert) {
-    const certObj = forge.pki.certificateFromPem(cert);
-    return this.#daysUntil(certObj.validity.notAfter) < 31;
+    const certObj = acme.crypto.readCertificateInfo(cert);
+    // const certObj = forge.pki.certificateFromPem(cert);
+    console.log(certObj);
+    // return this.#daysUntil(certObj.validity.notAfter) < 31;
+    return false;
   }
 
   /**
@@ -342,7 +345,7 @@ class Server {
    * @returns {Promise}
    */
 
-  async #challengeRemoveFn(authz, challenge, keyAuthorization) {
+  async #challengeRemoveFn(authz, challenge) {
     console.log("Cleaning up challenge");
 
     /* http-01 */

--- a/src/pinniped/server.js
+++ b/src/pinniped/server.js
@@ -1,0 +1,354 @@
+import {
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  existsSync,
+  chmodSync,
+} from "fs";
+import { createServer } from "https";
+import express from "express";
+import { Client, directory, crypto } from "acme-client";
+import forge from "node-forge";
+import { RecurrenceRule, scheduleJob } from "node-schedule";
+
+class Server {
+  constructor(expressApp, config) {
+    this.certServer = this.#createCertServer();
+    this.httpsServer;
+    this.httpServer;
+    this.httpRedirectServer;
+
+    this.expressApp = expressApp;
+    this.config = config;
+    this.credentials;
+    this.challengeCache = {};
+  }
+
+  /**
+   * Public method to start the server based on the config object passed in.
+   * @returns {undefined}
+   */
+
+  async start() {
+    if (this.config.domain) {
+      this.#startHttps();
+    } else {
+      this.#startHttp();
+    }
+  }
+
+  /**
+   * Starts a node https server and a redirect server
+   * @returns {undefined}
+   */
+
+  async #startHttps() {
+    await this.#getCredentials();
+
+    this.httpRedirectServer = this.#createRedirectServer();
+    this.httpRedirectServer.start();
+
+    this.httpsServer = this.#createHttpsServer();
+    this.httpsServer.start();
+    this.#startCertRenewalJob();
+  }
+
+  /**
+   * Starts an express server with no encryption
+   * @returns {undefined}
+   */
+
+  async #startHttp() {
+    this.httpServer = this.#createHttpServer();
+    this.httpServer.start();
+  }
+
+  /**
+   * Starts a node-schedule job to check the age if the certificate at 2am CST.
+   * If within 30 days of expiration will attempt to get a new cert.
+   * @returns {object}
+   */
+
+  async #startCertRenewalJob() {
+    const rule = new RecurrenceRule();
+    rule.minute = 0;
+    rule.hour = 2;
+    rule.tz = "Etc/GMT+5";
+
+    return scheduleJob(rule, async () => {
+      if (this.#needsRenewal(this.credentials.cert)) {
+        await this.#getCert();
+
+        this.credentials = this.#findCredentials();
+
+        this.httpsServer.stop();
+        this.httpsServer = this.#createHttpsServer();
+        this.httpsServer.start();
+      }
+    });
+  }
+
+  /**
+   * Gets the credentials, if they aren't found by findCredentials() or need renewal
+   * call getCert() to issue new credentials from Let's Encrypt.
+   * @returns {undefined}
+   */
+
+  #createHttpServer() {
+    let httpServer = {};
+    const app = this.expressApp;
+    const port = this.config.port || 3000;
+
+    httpServer.start = () => {
+      httpServer.server = app.listen(port, () => {
+        console.log(`\nServer started at: http://localhost:${port}`);
+        console.log(`├─ REST API: http://localhost:${port}/api`);
+        console.log(`└─ Admin UI: http://localhost:${port}/_/\n`);
+      });
+    };
+
+    httpServer.stop = async () => {
+      await httpServer.server.close();
+    };
+
+    return httpServer;
+  }
+
+  /**
+   * Gets the credentials, if they aren't found by findCredentials() or need renewal
+   * call getCert() to issue new credentials from Let's Encrypt.
+   * @returns {undefined}
+   */
+
+  async #getCredentials() {
+    let credentials = this.#findCredentials();
+
+    if (!credentials || this.#needsRenewal(credentials.cert)) {
+      await this.#getCert();
+      credentials = this.#findCredentials();
+    }
+    this.credentials = credentials;
+  }
+
+  /**
+   * Creates a node https server using the credentials and the express app passed in to the config object.
+   * @returns {object} https.Server
+   */
+  #createHttpsServer() {
+    let httpsServer = {};
+    httpsServer.server = createServer(this.credentials, this.expressApp);
+
+    httpsServer.start = () => {
+      this.httpsServer.server.listen(443, () => {
+        console.log("HTTPS server running on port 443");
+      });
+    };
+
+    httpsServer.stop = () => {
+      httpsServer.server.close();
+    };
+
+    return httpsServer;
+  }
+
+  /**
+   * Creates an express server to redirect any traffic on port 80 to port 443
+   * @returns {object} http.Server
+   */
+
+  #createRedirectServer() {
+    let redirectServer = {};
+    const redirectApp = express();
+
+    redirectApp.get("*", (req, res) => {
+      res.redirect("https://" + req.headers.host + req.url);
+    });
+
+    redirectServer.start = () => {
+      redirectServer.server = redirectApp.listen(80, () => {
+        console.log("Redirecting port 80 traffic to secure port 443.");
+      });
+    };
+    redirectServer.stop = async () => {
+      console.log("Closing redirect server");
+      await redirectServer.server.close();
+    };
+
+    return redirectServer;
+  }
+
+  /**
+   * Tries to get the server credentials, return undefined if unable to.
+   * @returns {object} privatekey and certificate
+   * @returns {undefined}
+   */
+
+  #findCredentials() {
+    let key;
+    let cert;
+    try {
+      key = readFileSync("pnpd_data/.cert/privkey.pem");
+      cert = readFileSync("pnpd_data/.cert/fullchain.pem");
+    } catch (e) {
+      console.log("Either private key or cert is missing.");
+      return undefined;
+    }
+
+    return { key, cert };
+  }
+
+  /**
+   * Returns number of days between a given date object and the current day.
+   * @param {object} Date object
+   * @returns {int}
+   */
+
+  #daysUntil(date) {
+    const today = new Date();
+    const dateCopy = new Date(date.getTime());
+
+    dateCopy.setUTCHours(0, 0, 0, 0);
+    today.setUTCHours(0, 0, 0, 0);
+
+    const diff = dateCopy - today;
+
+    // returns the diff as days
+    return diff / (1000 * 60 * 60 * 24);
+  }
+
+  /**
+   * Check if certificate is within 30 days of its expiration date
+   * @param {object} certificate.pem
+   * @returns {bool}
+   */
+  #needsRenewal(cert) {
+    const certObj = forge.pki.certificateFromPem(cert);
+    return this.#daysUntil(certObj.validity.notAfter) < 31;
+  }
+
+  /**
+   * Method to fetch certificate from Let's Encrypt. First stops the redirect server
+   * running on port 80, then starts a server to listen for the challenge from Let's Encrypt.
+   * Restarts redirect server when done.
+   *
+   * @returns {undefined}
+   */
+  async #getCert() {
+    if (this.httpRedirectServer) {
+      await this.httpRedirectServer.stop();
+    }
+    this.certServer.start();
+
+    /* Init client */
+    const client = new Client({
+      // uncomment this for production
+      // directoryUrl: directory.letsencrypt.production,
+      directoryUrl: directory.letsencrypt.staging,
+      accountKey: await crypto.createPrivateKey(),
+    });
+
+    /* Create CSR */
+    const [key, csr] = await crypto.createCsr({
+      commonName: this.config.domain || "jonathanhurd.net",
+    });
+
+    /* Certificate */
+    const cert = await client.auto({
+      csr,
+      termsOfServiceAgreed: true,
+      challengeCreateFn: this.#challengeCreateFn.bind(this),
+      challengeRemoveFn: this.#challengeRemoveFn.bind(this),
+    });
+
+    console.log("Obtained new certificate from Let's Encrypt");
+    if (!existsSync("pnpd_data/.cert")) {
+      mkdirSync("pnpd_data/.cert", { recursive: true });
+    }
+
+    writeFileSync("pnpd_data/.cert/privkey.pem", key);
+    chmodSync("pnpd_data/.cert/privkey.pem", 0o600);
+
+    writeFileSync("pnpd_data/.cert/fullchain.pem", cert);
+    chmodSync("pnpd_data/.cert/fullchain.pem", 0o644);
+
+    this.certServer.stop();
+    if (this.httpRedirectServer) {
+      this.httpRedirectServer.start();
+    }
+  }
+
+  /**
+   * Creates a server to listen on port 80 and respond to Let's Encrypt's
+   * challenge.
+   *
+   * @returns {object} http.Server
+   */
+  #createCertServer() {
+    let certServer = {};
+    const certApp = express();
+
+    certApp.get("/.well-known/acme-challenge/:token", (req, res) => {
+      res.send(this.challengeCache[req.params.token]);
+    });
+
+    certServer.start = () => {
+      certServer.server = certApp.listen(80, async () => {
+        console.log("Listening for challenges from Let's Encrypt");
+      });
+    };
+    certServer.stop = async () => {
+      console.log("Closing certificate challenge server");
+      await certServer.server.close();
+    };
+
+    return certServer;
+  }
+
+  /**
+   * Adds challenge.token and keyAuth to the challengeCache to serve as the
+   * Let's Encrypt challenge.
+   *
+   * @param {object} authz Authorization object
+   * @param {object} challenge Selected challenge
+   * @param {string} keyAuthorization Authorization key
+   * @returns {Promise}
+   */
+
+  async #challengeCreateFn(authz, challenge, keyAuthorization) {
+    console.log("Challenge recieved from Let's Encrypt");
+
+    /* http-01 */
+    if (challenge.type === "http-01") {
+      this.challengeCache[challenge.token] = keyAuthorization;
+    }
+  }
+
+  /**
+   * Removes challenge.token and keyAuth from challengeCache after the
+   * challenge has been satisfied.
+   *
+   * @param {object} authz Authorization object
+   * @param {object} challenge Selected challenge
+   * @param {string} keyAuthorization Authorization key
+   * @returns {Promise}
+   */
+
+  async #challengeRemoveFn(authz, challenge, keyAuthorization) {
+    console.log("Cleaning up challenge");
+
+    /* http-01 */
+    if (challenge.type === "http-01") {
+      delete this.challengeCache[challenge.token];
+    }
+  }
+}
+
+export default Server;
+// const app = express();
+
+// app.get("/", (req, res) => {
+//   res.send("Hi, this is seal!");
+// });
+
+// let server = new Server(this.expressApp, this.config);
+// server.start();

--- a/src/pinniped/server.js
+++ b/src/pinniped/server.js
@@ -20,10 +20,16 @@ class Server {
 
     this.expressApp = expressApp;
     this.config = config;
+    this.createAltNames();
     this.credentials;
     this.challengeCache = {};
   }
 
+  createAltNames() {
+    if (!this.config.altNames || !this.config.altNames.length) {
+      this.config.altNames.push("www." + this.config.domain);
+    }
+  }
   /**
    * Public method to start the server based on the config object passed in.
    * @returns {undefined}
@@ -249,7 +255,8 @@ class Server {
 
     /* Create CSR */
     const [key, csr] = await crypto.createCsr({
-      commonName: this.config.domain || "jonathanhurd.net",
+      commonName: this.config.domain,
+      altNames: this.config.altNames,
     });
 
     /* Certificate */

--- a/src/pinniped/server.js
+++ b/src/pinniped/server.js
@@ -27,15 +27,21 @@ class Server {
     this.httpRedirectServer;
 
     this.expressApp = expressApp;
-    this.config = config;
+    this.config = {
+      altNames: config.altNames || [],
+      port: config.port || 3000,
+      domain: config.domain,
+      cors: config.cors || [],
+    };
+
     this.createAltNames();
+    console.log(this.config);
     this.credentials;
     this.challengeCache = {};
   }
 
   createAltNames() {
-    if (!this.config.altNames || !this.config.altNames.length) {
-      this.config.altNames = [];
+    if (this.config.domain && !this.config.altNames.length) {
       this.config.altNames.push("www." + this.config.domain);
     }
   }
@@ -113,7 +119,7 @@ class Server {
   #createHttpServer() {
     let httpServer = {};
     const app = this.expressApp;
-    const port = this.config.port || 3000;
+    const port = this.config.port;
 
     httpServer.start = () => {
       httpServer.server = app.listen(port, () => {

--- a/src/pinniped/server.js
+++ b/src/pinniped/server.js
@@ -27,9 +27,11 @@ class Server {
 
   createAltNames() {
     if (!this.config.altNames || !this.config.altNames.length) {
+      this.config.altNames = [];
       this.config.altNames.push("www." + this.config.domain);
     }
   }
+
   /**
    * Public method to start the server based on the config object passed in.
    * @returns {undefined}


### PR DESCRIPTION
This branch brings in the Server class used to obtain Let's Encrypt certificates automatically. Changes to core app are minimal, the Server class is basically a wrapper used on app start.

Changes:
- `index.js` - We use a config object here to set our domain names or optionally a port number if running http only. Can leave empty, will default to running on http://localhost:3000. If a domain name is passed, server will attempt to get a certificate from Let's Encrypt.
- `pinniped.js` - instead of starting the app directly, we now create a new instance of `Server` and pass in the config object (set in index.js for now) and call the `start` method on the Server object.

Server class:
Depending on what is in the config object the Server will start as an http server on the localhost or if there is a domain name present in the config object it will attempt to obtain an SSL certificate. Either way, you pass an express app into the class that is used as the app server.

90% of the Server class is made up of methods that auto-cert your server with Let's Encrypt. It only supports `http-01` challenge types, which is the most common and most easily automated. To satisfy the Let's Encrypt's challenge you need to provide a certain value when Let's Encrypt requests it at `yourdomain/.well-know/acme-challenge/:token`. Do accomplish this, the class stores the token and value as a key-value pair on the class instance, when the challenge route is hit, the value associated with that token is fetched and returned to Let's Encrypt. 

`.createCertServer()` is an express server that starts up and shuts down to specifically serve Let's Encrypt challenges.

`.createRedirectServer()` is an express server that redirects port 80 traffic to 443. This is standard practice when running https.

`.createHttpServer()` is a basic http server running the passed in express app.

`.createHttpsServer()` is the method that kicks off all the auto-cert functionality. If no certificate or private key are found or the certificate is within 30 days of expiring, it will attempt to fetch new credentials from Let's Encrypt. Once those credentials are in place a node-schedule chron job runs at 2am CST every day to check the age of the certificate, the server will update the credentials if the certificate is within 30 days of expiring. Only once the new certificates are fetched will the main server restart with the new certificate and private key.
