### PR TITLE
Performance optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ pnpd.db-wal
 session.db
 migrations
 package-lock.json
+server.logs

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ app.addRoute("GET", "/seals", (req, res, next) => {
 // add event-driven functionality
 app.onGetOneRow.addListener(
   (event) => {
-    console.log("Triggered event: onGetAllRows");
+    console.log("Triggered event: onGetOneRow");
   },
   ["seals"]
 );

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "express-session": "^1.18.0",
     "helmet": "^7.1.0",
     "knex": "^3.1.0",
+    "memorystore": "^1.6.7",
     "node-schedule": "^2.1.1",
     "pino-http": "^9.0.0",
     "xss": "^1.0.15"

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "bcrypt": "^5.1.1",
     "better-sqlite3": "^9.4.3",
     "better-sqlite3-session-store": "^0.1.0",
+    "connect-session-knex": "^4.0.0",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.18.3",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "bcrypt": "^5.1.1",
     "better-sqlite3": "^9.4.3",
     "better-sqlite3-session-store": "^0.1.0",
-    "connect-session-knex": "^4.0.0",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.18.3",

--- a/src/api/init_api.js
+++ b/src/api/init_api.js
@@ -43,7 +43,6 @@ function initApi(app) {
 
   const logger = pino.destination({
     dest: "./pnpd_data/server.logs",
-    // minLength: 4096,
   });
 
   server.use(

--- a/src/api/middleware/load_table_context.js
+++ b/src/api/middleware/load_table_context.js
@@ -14,13 +14,11 @@ export default function loadTableContext(app) {
     const { table } = req.params;
     if (!table) throw new BadRequestError("Table Name or ID is required.");
 
-    let foundTable = await app.getDAO().findTableByNameOrId(table);
-    if (!foundTable.length) throw new TableNotFoundError(table);
-    foundTable = foundTable[0];
+    if (!app.tableContext[table]) {
+      await app.updateTableContext(table)
+    }
 
-    const tableContext = new Table(foundTable);
-
-    res.locals.table = tableContext;
+    res.locals.table = app.tableContext[table];
     next();
   });
 }

--- a/src/api/middleware/session_config.js
+++ b/src/api/middleware/session_config.js
@@ -1,32 +1,14 @@
 import session from "express-session";
-// import store from "better-sqlite3-session-store";
-// import sqlite from "better-sqlite3";
 import fs from "fs";
-import knex from "knex";
-import connectSessionKnex from "connect-session-knex";
+import memoryStore from "memorystore";
+const MemoryStore = memoryStore(session);
 
 import {
   createSessionSecret,
   saveSessionSecret,
 } from "../../utils/create_session_secret.js";
 
-// const SqliteStore = store(session);
 if (!fs.existsSync("pnpd_data")) fs.mkdirSync("pnpd_data");
-
-//creating a new knex connection with better-sqlite3 as the client
-let db = knex({
-  client: "better-sqlite3",
-  useNullAsDefault: true,
-  connection: {
-    filename: "pnpd_data/pnpd.db",
-  },
-  pool: {
-    afterCreate: function (connection, done) {
-      connection.pragma("journal_mode = WAL");
-      done(false, connection);
-    },
-  },
-});
 
 if (!process.env.SESSION_SECRET) {
   const secret = createSessionSecret();
@@ -36,18 +18,9 @@ if (!process.env.SESSION_SECRET) {
 
 export default function sessionConfig() {
   return session({
-    store: new (connectSessionKnex(session))({
-      knex: db,
-      clearInterval: 60000, // 1 min
+    store: new MemoryStore({
+      checkPeriod: 864000,
     }),
-    //setting up session store
-    // store: new SqliteStore({
-    //   client: db,
-    //   expired: {
-    //     clear: true,
-    //     intervalMs: 900000, //ms = 15min
-    //   },
-    // }),
     secret: process.env.SESSION_SECRET,
     resave: false,
     saveUninitialized: true,

--- a/src/api/middleware/session_config.js
+++ b/src/api/middleware/session_config.js
@@ -1,15 +1,32 @@
 import session from "express-session";
-import store from "better-sqlite3-session-store";
-import sqlite from "better-sqlite3";
+// import store from "better-sqlite3-session-store";
+// import sqlite from "better-sqlite3";
 import fs from "fs";
+import knex from "knex";
+import connectSessionKnex from "connect-session-knex";
+
 import {
   createSessionSecret,
   saveSessionSecret,
 } from "../../utils/create_session_secret.js";
 
-const SqliteStore = store(session);
+// const SqliteStore = store(session);
 if (!fs.existsSync("pnpd_data")) fs.mkdirSync("pnpd_data");
-const db = new sqlite("pnpd_data/session.db");
+
+//creating a new knex connection with better-sqlite3 as the client
+let db = knex({
+  client: "better-sqlite3",
+  useNullAsDefault: true,
+  connection: {
+    filename: "pnpd_data/pnpd.db",
+  },
+  pool: {
+    afterCreate: function (connection, done) {
+      connection.pragma("journal_mode = WAL");
+      done(false, connection);
+    },
+  },
+});
 
 if (!process.env.SESSION_SECRET) {
   const secret = createSessionSecret();
@@ -19,13 +36,18 @@ if (!process.env.SESSION_SECRET) {
 
 export default function sessionConfig() {
   return session({
-    store: new SqliteStore({
-      client: db,
-      expired: {
-        clear: true,
-        intervalMs: 900000, //ms = 15min
-      },
+    store: new (connectSessionKnex(session))({
+      knex: db,
+      clearInterval: 60000, // 1 min
     }),
+    //setting up session store
+    // store: new SqliteStore({
+    //   client: db,
+    //   expired: {
+    //     clear: true,
+    //     intervalMs: 900000, //ms = 15min
+    //   },
+    // }),
     secret: process.env.SESSION_SECRET,
     resave: false,
     saveUninitialized: true,

--- a/src/api/routers/schema.js
+++ b/src/api/routers/schema.js
@@ -77,6 +77,7 @@ class SchemaApi {
 
       const responseData = new ResponseData(req, res, { table });
       this.app.emitter.once("createTableEnd", () => {
+        this.app.tableContext[table.name] = table;
         if (responseData.responseSent()) return null;
         res.status(200).json({ table });
       });
@@ -100,7 +101,8 @@ class SchemaApi {
 
       const responseData = new ResponseData(req, res, { oldTable, newTable });
 
-      this.app.emitter.once("updateTableEnd", () => {
+      this.app.emitter.once("updateTableEnd", async () => {
+        this.app.tableContext[newTable.name] = newTable;
         if (responseData.responseSent()) return null;
         res.json({ table: newTable });
       });
@@ -124,6 +126,7 @@ class SchemaApi {
       const responseData = new ResponseData(req, res, { tableToDelete });
 
       this.app.emitter.once("dropTableEnd", () => {
+        delete this.app.tableContext[tableToDelete.name]
         if (responseData.responseSent()) return null;
         res.status(204).end();
       });

--- a/src/dao/log_dao.js
+++ b/src/dao/log_dao.js
@@ -1,51 +1,71 @@
 import knex from "knex";
 import generateRandomUuid from "../utils/generate_uuid.js";
+import fs from "fs";
 
 /**
  * Creates an Knex instance that connects to the better-sqlite3 'logs.db'.
  */
 class LogDao {
   constructor() {
-    this.db = knex({
-      client: "better-sqlite3",
-      useNullAsDefault: true,
-      connection: {
-        filename: "pnpd_data/logs.db",
-      },
-    });
+    // this.db = knex({
+    //   client: "better-sqlite3",
+    //   useNullAsDefault: true,
+    //   connection: {
+    //     afterCreate: function (connection, done) {
+    //       connection.pragma("journal_mode = WAL");
+    //       done(false, connection);
+    //     },
+    //     filename: "pnpd_data/logs.db",
+    //   },
+    // });
   }
 
   /**
    *  Creates the table 'logs' with its appropriate schema, following the structure of the custom logs structure.
    */
-  async createTable() {
-    const logsExists = await this.db.schema.hasTable("logs");
+  // async createTable() {
+  //   const logsExists = await this.db.schema.hasTable("logs");
 
-    if (!logsExists) {
-      await this.db.schema.createTable("logs", (table) => {
-        table.specificType("id", "TEXT PRIMARY KEY");
-        table.integer("pid");
-        table.integer("level");
-        table.string("time");
-        table.string("hostname");
-        table.string("method");
-        table.string("url");
-        table.json("headers");
-        table.integer("statusCode");
-        table.integer("responseTime");
-      });
-    }
-  }
+  //   if (!logsExists) {
+  //     await this.db.schema.createTable("logs", (table) => {
+  //       table.specificType("id", "TEXT PRIMARY KEY");
+  //       table.integer("pid");
+  //       table.integer("level");
+  //       table.string("time");
+  //       table.string("hostname");
+  //       table.string("method");
+  //       table.string("url");
+  //       table.json("headers");
+  //       table.integer("statusCode");
+  //       table.integer("responseTime");
+  //     });
+  //   }
+  // }
 
   async getLogs() {
-    return this.db("logs").select("*");
+    const data = fs.readFileSync("./pnpd_data/server.logs", "utf-8");
+    const lines = data.split("\n").filter((line) => line.trim() !== ""); // Split into lines and remove empty lines
+
+    const objectsArray = lines.map((line) => {
+      try {
+        return this.parseLog(line);
+      } catch (error) {
+        console.error("Error parsing JSON:", error, "Line:", line);
+        return null;
+      }
+    });
+    return objectsArray;
   }
 
-  async insertLog(log) {
-    return this.db("logs")
-      .insert(log)
-      .catch((err) => console.error(err));
-  }
+  // async getLogs() {
+  //   return this.db("logs").select("*");
+  // }
+
+  // async insertLog(log) {
+  //   return this.db("logs")
+  //     .insert(log)
+  //     .catch((err) => console.error(err));
+  // }
 
   async deleteLog(id) {
     await this.db("logs").where({ id }).del();
@@ -57,19 +77,22 @@ class LogDao {
    * On the condition that the request URL within the log is not from the '/api/admin/logs/ path or '/api/auth/' path.
    * This object gets returned to the Pino instance which allows this method to run on every log.
    */
-  sqliteStream() {
-    return {
-      write: (log) => {
-        const parsedLog = this.parseLog(log);
-        if (
-          parsedLog.url.startsWith("/api/admin/logs") ||
-          parsedLog.url === "/api/auth/"
-        )
-          return;
-        this.insertLog({ id: generateRandomUuid(), ...parsedLog });
-      },
-    };
-  }
+  // sqliteStream() {
+  //   return {
+  //     write: (log) => {
+  //       const parsedLog = this.parseLog(log);
+  //       if (
+  //         parsedLog.url.startsWith("/api/admin/logs") ||
+  //         parsedLog.url === "/api/auth/"
+  //       )
+  //         return;
+
+  //         // new TextEncoder().encode(JSON.stringify(parsedLog).length) / 1024
+  //       );
+  //       this.insertLog({ id: generateRandomUuid(), ...parsedLog });
+  //     },
+  //   };
+  // }
 
   /**
    * @param {obj} log
@@ -84,12 +107,13 @@ class LogDao {
       level,
       time,
       hostname,
-      req: { method, url, headers },
+      req: { method, url, headers, id },
       res: { statusCode },
       responseTime,
     } = copy;
 
     return {
+      id,
       pid,
       level,
       time,

--- a/src/dao/log_dao.js
+++ b/src/dao/log_dao.js
@@ -1,46 +1,7 @@
-// import knex from "knex";
-// import generateRandomUuid from "../utils/generate_uuid.js";
 import fs from "fs";
 
-/**
- * Creates an Knex instance that connects to the better-sqlite3 'logs.db'.
- */
 class LogDao {
-  constructor() {
-    // this.db = knex({
-    //   client: "better-sqlite3",
-    //   useNullAsDefault: true,
-    //   connection: {
-    //     afterCreate: function (connection, done) {
-    //       connection.pragma("journal_mode = WAL");
-    //       done(false, connection);
-    //     },
-    //     filename: "pnpd_data/logs.db",
-    //   },
-    // });
-  }
-
-  /**
-   *  Creates the table 'logs' with its appropriate schema, following the structure of the custom logs structure.
-   */
-  // async createTable() {
-  //   const logsExists = await this.db.schema.hasTable("logs");
-
-  //   if (!logsExists) {
-  //     await this.db.schema.createTable("logs", (table) => {
-  //       table.specificType("id", "TEXT PRIMARY KEY");
-  //       table.integer("pid");
-  //       table.integer("level");
-  //       table.string("time");
-  //       table.string("hostname");
-  //       table.string("method");
-  //       table.string("url");
-  //       table.json("headers");
-  //       table.integer("statusCode");
-  //       table.integer("responseTime");
-  //     });
-  //   }
-  // }
+  constructor() {}
 
   async getLogs() {
     const data = fs.readFileSync("./pnpd_data/server.logs", "utf-8");
@@ -57,16 +18,6 @@ class LogDao {
     return objectsArray;
   }
 
-  // async getLogs() {
-  //   return this.db("logs").select("*");
-  // }
-
-  // async insertLog(log) {
-  //   return this.db("logs")
-  //     .insert(log)
-  //     .catch((err) => console.error(err));
-  // }
-
   async deleteLog(id) {
     console.log(id);
     const data = fs.readFileSync("./pnpd_data/server.logs", "utf-8");
@@ -75,29 +26,6 @@ class LogDao {
     lines.splice(logIndex, 1);
     fs.writeFileSync("./pnpd_data/server.logs", lines.join("\n"));
   }
-
-  /**
-   * @return {object}
-   * Within the returned object contains a write method that optionally writes to 'logs.db'
-   * On the condition that the request URL within the log is not from the '/api/admin/logs/ path or '/api/auth/' path.
-   * This object gets returned to the Pino instance which allows this method to run on every log.
-   */
-  // sqliteStream() {
-  //   return {
-  //     write: (log) => {
-  //       const parsedLog = this.parseLog(log);
-  //       if (
-  //         parsedLog.url.startsWith("/api/admin/logs") ||
-  //         parsedLog.url === "/api/auth/"
-  //       )
-  //         return;
-
-  //         // new TextEncoder().encode(JSON.stringify(parsedLog).length) / 1024
-  //       );
-  //       this.insertLog({ id: generateRandomUuid(), ...parsedLog });
-  //     },
-  //   };
-  // }
 
   /**
    * @param {obj} log

--- a/src/dao/log_dao.js
+++ b/src/dao/log_dao.js
@@ -1,5 +1,5 @@
-import knex from "knex";
-import generateRandomUuid from "../utils/generate_uuid.js";
+// import knex from "knex";
+// import generateRandomUuid from "../utils/generate_uuid.js";
 import fs from "fs";
 
 /**
@@ -68,7 +68,12 @@ class LogDao {
   // }
 
   async deleteLog(id) {
-    await this.db("logs").where({ id }).del();
+    console.log(id);
+    const data = fs.readFileSync("./pnpd_data/server.logs", "utf-8");
+    let lines = data.split("\n");
+    const logIndex = lines.findIndex((log) => log.includes(id));
+    lines.splice(logIndex, 1);
+    fs.writeFileSync("./pnpd_data/server.logs", lines.join("\n"));
   }
 
   /**

--- a/src/pinniped/pinniped.js
+++ b/src/pinniped/pinniped.js
@@ -3,7 +3,7 @@ import DAO from "../dao/dao.js";
 import LogDao from "../dao/log_dao.js";
 import EventEmitter from "events";
 import registerProcessListeners from "../utils/register_process_listeners.js";
-import { InvalidCustomRouteError } from "../utils/errors.js";
+import { InvalidCustomRouteError, TableNotFoundError } from "../utils/errors.js";
 import Table from "../models/table.js";
 import PinnipedEvent from "../models/pnpd_event.js";
 import Server from "./server.js";
@@ -26,6 +26,16 @@ class Pinniped {
     this.customRoutes = [];
     this.dataBaseSetup();
     this.initEvents();
+    this.tableContext = {};
+  }
+
+  async updateTableContext(tableName) {
+    let foundTable = await this.DAO.findTableByNameOrId(tableName);
+    if (!foundTable.length) throw new TableNotFoundError(tableName);
+    foundTable = foundTable[0];
+
+    const tableContext = new Table(foundTable);
+    this.tableContext[tableName] = tableContext;
   }
 
   async dataBaseSetup() {

--- a/src/pinniped/pinniped.js
+++ b/src/pinniped/pinniped.js
@@ -31,7 +31,7 @@ class Pinniped {
   async dataBaseSetup() {
     await this.runLatestMigrations();
     await this.seedDatabase();
-    await this.logger.createTable();
+    // await this.logger.createTable();
   }
   /**
    * Seeds the database with the necessary tables.

--- a/src/utils/generate_uuid.js
+++ b/src/utils/generate_uuid.js
@@ -1,5 +1,5 @@
 import crypto from "crypto";
 
-export default function generateRandomUUID(size = 7) {
-  return crypto.randomBytes(size).toString("hex");
+export default function generateRandomUUID() {
+  return crypto.randomBytes(7).toString("hex");
 }


### PR DESCRIPTION
These changes are all about getting the RPS of the backend up a bit. In my rudimentary load testing, I was maxing at ~300 RPS which is less than ideal. After these changes, we're in the range of ~1500 RPS.

**Changes:**
This was a bit of a whack-a-mole set of changes that needed to be made. Our primary bottleneck was disk I/O with a bunch of contributors to the problem. I'll outline the changes made below. 

**Sessions**
We were storing persistent sessions in a SQLite database - I've changed the session storage to an in-memory store. This is the biggest change that we'd feel in development as anytime the server restarts you'll need to log in again. Anyone who's working on the backend could implement a simple workaround if it becomes a problem.

**Logs**
Common theme: we were storing our logs in a SQLite database. I've re-written the code to append new logs to a text file which is faster. Future work here would be to rotate out the log file when it gets too large and compress/store old log files.

**LoadTableContext**
This was a big one - because `LoadTableContext` middleware needs to know the current schema of all tables in the database its been querying the database for every request before making the primary query, effectively doubling the load on the DB. I've updated the middleware to check a cache to see if the table context has loaded before querying the DB. Along with that change, I updated all schema change routes to tell the server that the cache is stale and it should reload after a schema change is made.

There's only one minor change on the front end relating to how the logs format has changed which will need to be pulled in separately for everything to work.